### PR TITLE
Add support for Appium 1.6 / iOS 10

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,9 +46,9 @@ exports.getDefaultCapabilities = function() {
     if (testRunType === "android") {
         return exports.caps.android19();
     } else if (testRunType === "ios-simulator") {
-        return exports.caps.ios92();
+        return exports.caps.ios10();
     } else if (testRunType === "ios") {
-        return exports.caps.ios92();
+        return exports.caps.ios10();
     } else {
         throw new Error("Incorrect test run type: " + testRunType);
     }
@@ -73,7 +73,7 @@ exports.configureLogging = function(driver) {
 };
 
 exports.caps = {
-    android19: function(){ 
+    android19: function(){
         return {
             browserName: '',
             'appium-version': '1.5',
@@ -83,12 +83,22 @@ exports.caps = {
             app: undefined // will be set later
         };
     },
-    ios92: function() { 
+    ios92: function() {
         return {
             browserName: '',
             'appium-version': '1.5',
             platformName: 'iOS',
             platformVersion: '9.2',
+            deviceName: 'iPhone 6',
+            app: undefined // will be set later
+        };
+    },
+    ios10: function() {
+        return {
+            browserName: '',
+            'appium-version': '1.6',
+            platformName: 'iOS',
+            platformVersion: '10.0',
             deviceName: 'iPhone 6',
             app: undefined // will be set later
         };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-dev-appium",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "A NativeScript plugin to help integrate and run Appium tests",
   "main": "index.js",
   "bin": {
@@ -23,7 +23,7 @@
   "dependencies": {
     "glob": "*",
     "wd": "^0.4.0",
-    "appium": "1.5.2",
+    "appium": "1.6.0",
     "colors": "^1.1.2",
     "mocha": "^2.4.5",
     "portastic": "^1.0.1"


### PR DESCRIPTION
With these changes I was successfully able to run an Appium test against iOS 10 with `nativescript-dev-appium`. See https://github.com/appium/appium/releases/tag/v1.6.0 for details of the Appium 1.6 release and its support for iOS 10 / XCode 8.