### PR TITLE
Fix `Error: EISDIR: illegal operation on a directory, read` error

### DIFF
--- a/lib/capabilities-helper.ts
+++ b/lib/capabilities-helper.ts
@@ -13,8 +13,8 @@ export function resolveCapabilities(capsLocation: string, runType: string, proje
         utils.log(customCapabilities, verbose);
 
         caps = customCapabilities[runType];
-    } 
-    
+    }
+
     if (!customCapabilitiesConfigs || !caps) {
         throw new Error("No capabilities found!!!");
     }
@@ -42,7 +42,7 @@ export function searchCapabilities(capabilitiesLocation, projectDir, verbose: bo
     }
 
     if (customCapabilitiesLocation && customCapabilitiesLocation.length > 0 && utils.fileExists(customCapabilitiesLocation)) {
-        return seCapabilities(customCapabilitiesLocation[0]);
+        return seCapabilities(customCapabilitiesLocation);
     }
 
     throw Error("No capabilities found!!!");


### PR DESCRIPTION
It tries to read the `/` directory as a file (at least on Linux) because `sreachCapabilitiesByFolder` already does the `[0]` operation.

The `sreachCapabilitiesByFolder` search for capabilities files on a folder, so it build an array of file paths, but it returns only the first one. But, the `searchCapabilities` again indexes the first element, so we pass from:
```
// built on sreachCapabilitiesByFolder
['/path/to/file1.json', '/path/to/file2.json', ...]
```
to:
```
// returned in sreachCapabilitiesByFolder
'/path/to/file1.json'
```
and then we did `[0]` again so we get:
```
'/'
```
and the error happened when we do `readFileSync('/')` on the `seCapabilities()` function.