### PR TITLE
docs: add Jasmine-specific note about params to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,11 @@ $ npm run e2e -- --device.name=/iPhone X/ --device.apiLevel=/12.1/
 
 Generated tests are standard [Mocha](http://mochajs.org) tests.
 
+NOTE: When using Jasmine instead of Mocha, additional npm params (like `runType`) must have an equal sign (=) instead of a space.
+```
+npm run e2e -- --runType=sim.iPhoneX
+```
+
 ## Blogs
 
 2018, March 6th: [Start Testing Your NativeScript Apps Properly](https://www.nativescript.org/blog/start-testing-your-nativescript-apps-properly)


### PR DESCRIPTION
Added a small note to the readme about using the automatically scaffolded `npm run e2e` script with jasmine. This detail would have saved me some frustration.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [x] Tests for the changes are included

Addresses #219.
