### PR TITLE
fix: remove duplicated property

### DIFF
--- a/lib/appium-driver.ts
+++ b/lib/appium-driver.ts
@@ -547,26 +547,31 @@ export class AppiumDriver {
         logInfo(`Set device orientation: ${orientation}`)
         await this._driver.setOrientation(orientation);
 
-        // if ((<NsCapabilities>this.nsCapabilities).tryGetApiLevel() < 6.0 && orientation === DeviceOrientation.LANDSCAPE) {
-        if (orientation === DeviceOrientation.LANDSCAPE) {
-            if (this.isAndroid) {
-                this.imageHelper.options.cropRectangle.x = 0;
+        if (orientation === DeviceOrientation.LANDSCAPE && this.isAndroid) {
+            if ((<NsCapabilities>this.nsCapabilities).tryGetApiLevel() < 6.0) {
+                // HACK since the image is rotated and action bar is on the bottom of the image, it is needed to exclude action bar from bottom.
                 const height = this._imageHelper.options.cropRectangle.width - this._imageHelper.options.cropRectangle.y;
                 const width = this._imageHelper.options.cropRectangle.height + this._imageHelper.options.cropRectangle.y;
                 this.imageHelper.options.cropRectangle.y = 0;
-
                 this.imageHelper.options.cropRectangle.width = width;
                 this.imageHelper.options.cropRectangle.height = height;
-            } else {
-                this.imageHelper.options.cropRectangle.x = 0;
-                const height = this._imageHelper.options.cropRectangle.width;
-                const width = this._imageHelper.options.cropRectangle.height + this._imageHelper.options.cropRectangle.y;
-                this.imageHelper.options.cropRectangle.y = 0;
-
+            } else if ((<NsCapabilities>this.nsCapabilities).tryGetApiLevel() >= 6.0) {
+                const height = this._imageHelper.options.cropRectangle.width - this.imageHelper.options.cropRectangle.y;
+                const width = this._imageHelper.options.cropRectangle.height + this.imageHelper.options.cropRectangle.y;
                 this.imageHelper.options.cropRectangle.width = width;
                 this.imageHelper.options.cropRectangle.height = height;
             }
-        } else {
+        }
+        else if (orientation === DeviceOrientation.LANDSCAPE && this.isIOS) {
+            this.imageHelper.options.cropRectangle.x = 0;
+            const height = this._imageHelper.options.cropRectangle.width;
+            const width = this._imageHelper.options.cropRectangle.height + this._imageHelper.options.cropRectangle.y;
+            this.imageHelper.options.cropRectangle.y = 0;
+
+            this.imageHelper.options.cropRectangle.width = width;
+            this.imageHelper.options.cropRectangle.height = height;
+        }
+        else {
             this.imageHelper.resetDefaultOptions();
         }
     }

--- a/lib/appium-driver.ts
+++ b/lib/appium-driver.ts
@@ -48,6 +48,7 @@ import { LogType } from "./log-types";
 import { screencapture } from "./helpers/screenshot-manager";
 import { LogImageType } from "./enums/log-image-type";
 import { DeviceOrientation } from "./enums/device-orientation";
+import { NsCapabilities } from "./ns-capabilities";
 
 export class AppiumDriver {
     private _defaultWaitTime: number = 5000;
@@ -546,13 +547,27 @@ export class AppiumDriver {
         logInfo(`Set device orientation: ${orientation}`)
         await this._driver.setOrientation(orientation);
 
+        // if ((<NsCapabilities>this.nsCapabilities).tryGetApiLevel() < 6.0 && orientation === DeviceOrientation.LANDSCAPE) {
         if (orientation === DeviceOrientation.LANDSCAPE) {
-            this.imageHelper.imageCropRect.x = this._imageHelper.options.cropRectangle.x;
-            this.imageHelper.imageCropRect.y = this._imageHelper.options.cropRectangle.y;
-            this.imageHelper.imageCropRect.width = this._imageHelper.options.cropRectangle.height;
-            this.imageHelper.imageCropRect.height = this._imageHelper.options.cropRectangle.width;
+            if (this.isAndroid) {
+                this.imageHelper.options.cropRectangle.x = 0;
+                const height = this._imageHelper.options.cropRectangle.width - this._imageHelper.options.cropRectangle.y;
+                const width = this._imageHelper.options.cropRectangle.height + this._imageHelper.options.cropRectangle.y;
+                this.imageHelper.options.cropRectangle.y = 0;
+
+                this.imageHelper.options.cropRectangle.width = width;
+                this.imageHelper.options.cropRectangle.height = height;
+            } else {
+                this.imageHelper.options.cropRectangle.x = 0;
+                const height = this._imageHelper.options.cropRectangle.width;
+                const width = this._imageHelper.options.cropRectangle.height + this._imageHelper.options.cropRectangle.y;
+                this.imageHelper.options.cropRectangle.y = 0;
+
+                this.imageHelper.options.cropRectangle.width = width;
+                this.imageHelper.options.cropRectangle.height = height;
+            }
         } else {
-            this.imageHelper.imageCropRect = undefined;
+            this.imageHelper.resetDefaultOptions();
         }
     }
 

--- a/lib/image-helper.d.ts
+++ b/lib/image-helper.d.ts
@@ -63,7 +63,6 @@ export declare class ImageHelper {
     private _driver;
     private _blockOutAreas;
     private _imagesResults;
-    private _imageCropRect;
     private _options;
     private _defaultOptions;
     constructor(_args: INsCapabilities, _driver: AppiumDriver);
@@ -80,7 +79,6 @@ export declare class ImageHelper {
      */
     delta: number;
     options: IImageCompareOptions;
-    imageCropRect: IRectangle;
     blockOutAreas: IRectangle[];
     compareScreen(options?: IImageCompareOptions): Promise<boolean>;
     compareElement(element: UIElement, options?: IImageCompareOptions): Promise<boolean>;
@@ -97,7 +95,7 @@ export declare class ImageHelper {
     getExpectedImagePathByDevice(imageName: string): string;
     getExpectedImagePathByPlatform(imageName: string): string;
     compare(options: IImageCompareOptions): Promise<boolean>;
-    compareImages(actual: string, expected: string, output: string, tolerance: number, toleranceType: ImageOptions): Promise<boolean>;
+    compareImages(options: IImageCompareOptions, actual: string, expected: string, output: string): Promise<boolean>;
     clipRectangleImage(rect: IRectangle, path: string): Promise<{}>;
     readImage(path: string): Promise<any>;
     private runDiff;

--- a/lib/ns-capabilities.d.ts
+++ b/lib/ns-capabilities.d.ts
@@ -74,10 +74,9 @@ export declare class NsCapabilities implements INsCapabilities {
     extend(args: INsCapabilities): this;
     validateArgs(): Promise<void>;
     private isAndroidPlatform;
-    shouldSetFullResetOption(): void;
+    setResetOption(): void;
+    tryGetApiLevel(): number;
     private setAutomationName;
-    tryGetAndroidApiLevel(): number;
-    tryGetIOSApiLevel(): number;
     private resolveApplication;
     private checkMandatoryCapabilities;
     private throwExceptions;

--- a/lib/ns-capabilities.ts
+++ b/lib/ns-capabilities.ts
@@ -263,7 +263,7 @@ export class NsCapabilities implements INsCapabilities {
             this.resolveApplication();
             this.checkMandatoryCapabilities();
             this.throwExceptions();
-            this.shouldSetFullResetOption();
+            this.setResetOption();
 
             this.isValidated = true;
         } else {
@@ -275,7 +275,7 @@ export class NsCapabilities implements INsCapabilities {
         return this.appiumCaps && this.appiumCaps ? this.appiumCaps.platformName.toLowerCase().includes("android") : undefined;
     }
 
-    public shouldSetFullResetOption() {
+    public setResetOption() {
         if (this.attachToDebug || this.devMode) {
             this.appiumCaps["fullReset"] = false;
             this.appiumCaps["noReset"] = true;
@@ -300,6 +300,18 @@ export class NsCapabilities implements INsCapabilities {
         }
     }
 
+    public tryGetApiLevel() {
+        try {
+            const apiLevel = this.appiumCaps["platformVersion"] || this.appiumCaps["apiLevel"];
+            if (this.isAndroid && apiLevel) {
+                return +apiLevel.split(".").splice(0, 2).join('.');
+            }
+            return +apiLevel;
+        } catch (error) { }
+
+        return undefined;
+    }
+
     private setAutomationName() {
         if (this.appiumCaps["automationName"]) {
             switch (this.appiumCaps["automationName"].toLowerCase()) {
@@ -313,7 +325,7 @@ export class NsCapabilities implements INsCapabilities {
                     this.automationName = AutomationName.UiAutomator1; break;
             }
         } else {
-            const apiLevel = this.tryGetApiLevel();
+            const apiLevel = +this.tryGetApiLevel();
             if (this.isAndroid) {
                 if ((apiLevel >= 6 && apiLevel <= 17)
                     || apiLevel >= 23) {
@@ -339,18 +351,6 @@ export class NsCapabilities implements INsCapabilities {
         } else {
             console.log(`Appium will use default automation name`);
         }
-    }
-
-    tryGetApiLevel() {
-        try {
-            const apiLevel = this.appiumCaps["platformVersion"] || this.appiumCaps["apiLevel"];
-            if (this.isAndroid && apiLevel) {
-                return apiLevel.split(".").splice(0, 2).join('.');
-            }
-            return apiLevel;
-        } catch (error) { }
-
-        return undefined;
     }
 
     private resolveApplication() {

--- a/test/device-manager.spec.ts
+++ b/test/device-manager.spec.ts
@@ -83,7 +83,7 @@ describe("ios-devices", () => {
         deviceManager = new DeviceManager();
         appiumArgs = new NsCapabilities(<any>{});
         appiumArgs.extend(<any>{ appiumCaps: { platformName: Platform.IOS, fullReset: false, deviceName: /iPhone X/ } })
-        appiumArgs.shouldSetFullResetOption();
+        appiumArgs.setResetOption();
     });
 
     after("Kill all simulators", () => {
@@ -101,7 +101,7 @@ describe("ios-devices", () => {
 
     it("Start simulator fullReset: true, should kill device", async () => {
         appiumArgs.extend(<any>{ appiumCaps: { platformName: Platform.IOS, fullReset: true, deviceName: /iPhone X/ } });
-        appiumArgs.shouldSetFullResetOption();
+        appiumArgs.setResetOption();
         const device = await deviceManager.startDevice(appiumArgs);
         let foundBootedDevices = await DeviceController.getDevices({ platform: Platform.IOS, status: Status.BOOTED });
         assert.isTrue(foundBootedDevices.some(d => d.token === device.token));


### PR DESCRIPTION

BREAKING CHANGES:


Removed imageCropRect

Migration steps:
Before 
`imageCropRect = {x: , y: , width: ,height: }`
Now:
`imageHelper.options.cropRectangle`

Change viewPort when  device orientation = DeviceOrientation.LANDSCAPE. 
Before:
It has cut the image
Now will take the whole image.

